### PR TITLE
Support Gardener credentials data keys

### DIFF
--- a/kubernetes/secret.yaml
+++ b/kubernetes/secret.yaml
@@ -11,4 +11,7 @@ data:
   userData: {{ $machineClass.secret.userData | b64enc }}
   alicloudAccessKeyID: {{ $machineClass.secret.accessKeyID | b64enc }}
   alicloudAccessKeySecret: {{ $machineClass.secret.accessKeySecret | b64enc }}
+### Alternative data keys are:
+# accessKeyID: "alicloud-access-key-id" # Alicloud access key ID (base64 encoded)
+# accessKeySecret: "alicloud-access-key-secret" # Alicloud secret access key (base64 encoded)
 type: Opaque


### PR DESCRIPTION
/area open-source usability
/kind enhancement
/priority normal
/platform alicloud

**What this PR does / why we need it**:
All the secret keys used by Gardener are now also allowed as alternatives for this machine-controller-manager plugin. This helps to not make mappings for the data keys.

**Special notes for your reviewer**:
ℹ️ Similar improvement for in-tree driver: https://github.com/gardener/machine-controller-manager/pull/578/commits/0e41070979b21dae4e27fe6504bdc99f651ec3b7 (https://github.com/gardener/machine-controller-manager/pull/578)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```feature operator
The machine class secret does now also accept the data keys `accessKeyID` and `accessKeySecret` as alternatives for today's keys.
```