### PR TITLE
change equal to consistof for slice

### DIFF
--- a/pkg/alicloud/machine_controller_test.go
+++ b/pkg/alicloud/machine_controller_test.go
@@ -319,16 +319,10 @@ var _ = Describe("Machine Controller", func() {
 					},
 				},
 			}
-			getVolumeIDsResponse = &driver.GetVolumeIDsResponse{
-				VolumeIDs: []string{
-					"d-mockflexvolumeid",
-					"d-mockcsivolumeid",
-				},
-			}
 		)
 
 		response, err := mockMachinePlugin.GetVolumeIDs(ctx, getVolumeIDsRequest)
 		Expect(err).To(BeNil())
-		Expect(response).To(Equal(getVolumeIDsResponse))
+		Expect(response.VolumeIDs).To(ConsistOf("d-mockflexvolumeid", "d-mockcsivolumeid"))
 	})
 })

--- a/pkg/spi/spi_test.go
+++ b/pkg/spi/spi_test.go
@@ -88,16 +88,15 @@ var _ = Describe("Plugin SPI", func() {
 		Expect(request.SystemDiskCategory).To(Equal("cloud_efficiency"))
 		Expect(request.SystemDiskSize).To(Equal("50"))
 		Expect(request.DataDisk).To(BeNil())
-		Expect(request.Tag).To(Equal(&[]ecs.RunInstancesTag{
-			{
+		Expect(*request.Tag).To(ConsistOf(
+			ecs.RunInstancesTag {
 				Key:   "kubernetes.io/cluster/shoot--mcm",
 				Value: "1",
-			},
-			{
+			}, ecs.RunInstancesTag {
 				Key:   "kubernetes.io/role/worker/shoot--mcm",
 				Value: "1",
 			},
-		}))
+		))
 	})
 
 	It("should generate request of describing instance by machine Name", func() {
@@ -142,26 +141,24 @@ var _ = Describe("Plugin SPI", func() {
 	It("should generate instance data disks", func() {
 		dataDisks := pluginSPI.NewInstanceDataDisks(alicloudDataDisks, machineName)
 		Expect(dataDisks).NotTo(BeEmpty())
-		Expect(dataDisks).To(Equal([]ecs.RunInstancesDataDisk{
-			{
-				Category:           "DiskEphemeralSSD",
-				Encrypted:          "true",
-				DiskName:           "plugin-test-machine-disk-1-data-disk",
-				Size:               "50",
-				DeleteWithInstance: "",
-			},
-			{
-				Encrypted:          "true",
-				DiskName:           "plugin-test-machine-disk-2-data-disk",
-				Size:               "100",
-				DeleteWithInstance: "false",
-			},
-			{
-				Encrypted:          "false",
-				DiskName:           "plugin-test-machine-disk-3-data-disk",
-				Size:               "20",
-				DeleteWithInstance: "true",
-			},
-		}))
+		Expect(dataDisks).To(ConsistOf(
+			ecs.RunInstancesDataDisk {
+					Category:           "DiskEphemeralSSD",
+					Encrypted:          "true",
+					DiskName:           "plugin-test-machine-disk-1-data-disk",
+					Size:               "50",
+					DeleteWithInstance: "",
+				}, ecs.RunInstancesDataDisk{
+					Encrypted:          "true",
+					DiskName:           "plugin-test-machine-disk-2-data-disk",
+					Size:               "100",
+					DeleteWithInstance: "false",
+				}, ecs.RunInstancesDataDisk{
+					Encrypted:          "false",
+					DiskName:           "plugin-test-machine-disk-3-data-disk",
+					Size:               "20",
+					DeleteWithInstance: "true",
+				},
+		))
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to change `equal` to `consist of` for slice comparison.
**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:
None
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
None
```