### PR TITLE
add field indicating encryption of system disk

### DIFF
--- a/pkg/alicloud/apis/alicloud_provider_spec.go
+++ b/pkg/alicloud/apis/alicloud_provider_spec.go
@@ -52,6 +52,7 @@ type AlicloudDataDisk struct {
 
 // AlicloudSystemDisk describes SystemDisk for Alicloud.
 type AlicloudSystemDisk struct {
-	Category string `json:"category"`
-	Size     int    `json:"size"`
+	Category  string `json:"category"`
+	Size      int    `json:"size"`
+	Encrypted bool   `json:"encrypted,omitEmpty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add one field named `Encrypted` in `AlicloudSystemDisk` for the indication of encryption of system disk. The default value should be `False`.
**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
One new field named `Encrypted` in `AlicloudSystemDisk` is added to indicate the encryption of system disk. 
```