### PR TITLE
Automated cherry pick of #23: images updated

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,12 +19,12 @@ machine-controller-manager-provider-alicloud:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud'
     steps:
       check:
-        image: 'golang:1.15.5'
+        image: 'golang:1.17.9'
       build:
-        image: 'golang:1.15.5'
+        image: 'golang:1.17.9'
         output_dir: 'binary'
       test:
-        image: 'golang:1.15.5'
+        image: 'golang:1.17.9'
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM golang:1.15.5 AS builder
+FROM golang:1.17.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-alicloud
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM alpine:3.12.1 as base
+FROM alpine:3.15.4 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /


### PR DESCRIPTION
Cherry pick of #23 on rel-v0.3.

#23: images updated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Base image updated to alpine `v3.15.4` and build image to golang `1.17.9`.
```