### PR TITLE
Fix `.ci/set_dependency_version`

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -35,6 +35,6 @@ old_version=$(cat go.mod | grep "github.com/gardener/machine-controller-manager 
 new_version="github.com/gardener/machine-controller-manager ${DEPENDENCY_VERSION}"
 sed -i -- 's#'"${old_version}"'#'"${new_version}"'#g' go.mod
 
-#apk add --no-cache go make
+apk add --no-cache go make
 
 make revendor


### PR DESCRIPTION
**What this PR does / why we need it**:
The concourse job to raise PRs to update the version of mcm to the latest one automatically is not working because of a commented line in `set_dependency_version`. This PR uncomments that line.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```