### PR TITLE
`ResourceExhausted` error code mapping introduced for `Alicloud`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /tmp/*
 /dev
 /logs
+.ci/controllers-test/logs
 
 .vscode
 .idea

--- a/pkg/alicloud/errors/codes.go
+++ b/pkg/alicloud/errors/codes.go
@@ -1,0 +1,29 @@
+package errors
+
+// constants for alicloud `RunInstances()` response error code which map to MCM `ResourceExhausted` code
+const(
+// QuotaExceededDiskCapacity: The used capacity of disk type has exceeded the quota in the zone
+QuotaExceededDiskCapacity="QuotaExceed.DiskCapacity"
+// QuotaExceededElasticQuota: The number of vCPUs assigned to the ECS instances has exceeded the quota in the zone. Please sign-on to Alibaba Cloud Console, and submit a quota increase application.
+QuotaExceededElasticQuota="QuotaExceed.ElasticQuota"
+// OperationDeniedZoneSystemCategoryNotMatch: The specified Zone or cluster does not offer the specified disk category or the specified zone and cluster do not match.
+OperationDeniedZoneSystemCategoryNotMatch="OperationDenied.ZoneSystemCategoryNotMatch"
+// OperationDeniedCloudSSDNotSupported: The specified available zone does not offer the cloud_ssd disk, use cloud_essd instead.
+OperationDeniedCloudSSDNotSupported="OperationDenied.CloudSSDNotSupported"
+// OperationDeniedZoneNotAllowed: The creation of Instance to the specified Zone is not allowed.
+OperationDeniedZoneNotAllowed="OperationDenied.ZoneNotAllowed"
+// OperationDeniedNoStock: The requested resource is sold out in the specified zone; try other types of resources or other regions and zones.
+OperationDeniedNoStock="OperationDenied.NoStock"
+// ZoneNotOnSale: The resource in the specified zone is no longer available for sale. Please try other regions and zones.
+ZoneNotOnSale="Zone.NotOnSale"
+// ZoneNotOpen: The specified zone is not granted to you to buy resources yet.
+ZoneNotOpen="Zone.NotOpen"
+// InvalidVpcZone.NotSupported: The specified operation is not allowed in the zone to which your VPC belongs, please try in other zones.
+InvalidVpcZoneNotSupported="InvalidVpcZone.NotSupported"
+// InvalidZoneIdNotSupportShareEncryptedImage: Creating instances by shared encrypted images is not supported in this zone.
+InvalidZoneIdNotSupportShareEncryptedImage="InvalidZoneId.NotSupportShareEncryptedImage"
+// InvalidInstanceType.ZoneNotSupported: The specified zone does not support this instancetype.
+InvalidInstanceTypeZoneNotSupported="InvalidInstanceType.ZoneNotSupported"
+// ResourceNotAvailable: Resource you requested is not available in this region or zone.
+ResourceNotAvailable="ResourceNotAvailable"
+)

--- a/pkg/alicloud/errors/codes.go
+++ b/pkg/alicloud/errors/codes.go
@@ -1,3 +1,15 @@
+/*
+Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package errors
 
 // constants for alicloud `RunInstances()` response error code which map to MCM `ResourceExhausted` code

--- a/pkg/alicloud/errors/codes.go
+++ b/pkg/alicloud/errors/codes.go
@@ -3,39 +3,43 @@ Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package errors contains the error codes returned by Alicloud APIs
 package errors
 
 // constants for alicloud `RunInstances()` response error code which map to MCM `ResourceExhausted` code
-const(
-// QuotaExceededDiskCapacity: The used capacity of disk type has exceeded the quota in the zone
-QuotaExceededDiskCapacity="QuotaExceed.DiskCapacity"
-// QuotaExceededElasticQuota: The number of vCPUs assigned to the ECS instances has exceeded the quota in the zone. Please sign-on to Alibaba Cloud Console, and submit a quota increase application.
-QuotaExceededElasticQuota="QuotaExceed.ElasticQuota"
-// OperationDeniedZoneSystemCategoryNotMatch: The specified Zone or cluster does not offer the specified disk category or the specified zone and cluster do not match.
-OperationDeniedZoneSystemCategoryNotMatch="OperationDenied.ZoneSystemCategoryNotMatch"
-// OperationDeniedCloudSSDNotSupported: The specified available zone does not offer the cloud_ssd disk, use cloud_essd instead.
-OperationDeniedCloudSSDNotSupported="OperationDenied.CloudSSDNotSupported"
-// OperationDeniedZoneNotAllowed: The creation of Instance to the specified Zone is not allowed.
-OperationDeniedZoneNotAllowed="OperationDenied.ZoneNotAllowed"
-// OperationDeniedNoStock: The requested resource is sold out in the specified zone; try other types of resources or other regions and zones.
-OperationDeniedNoStock="OperationDenied.NoStock"
-// ZoneNotOnSale: The resource in the specified zone is no longer available for sale. Please try other regions and zones.
-ZoneNotOnSale="Zone.NotOnSale"
-// ZoneNotOpen: The specified zone is not granted to you to buy resources yet.
-ZoneNotOpen="Zone.NotOpen"
-// InvalidVpcZone.NotSupported: The specified operation is not allowed in the zone to which your VPC belongs, please try in other zones.
-InvalidVpcZoneNotSupported="InvalidVpcZone.NotSupported"
-// InvalidZoneIdNotSupportShareEncryptedImage: Creating instances by shared encrypted images is not supported in this zone.
-InvalidZoneIdNotSupportShareEncryptedImage="InvalidZoneId.NotSupportShareEncryptedImage"
-// InvalidInstanceType.ZoneNotSupported: The specified zone does not support this instancetype.
-InvalidInstanceTypeZoneNotSupported="InvalidInstanceType.ZoneNotSupported"
-// ResourceNotAvailable: Resource you requested is not available in this region or zone.
-ResourceNotAvailable="ResourceNotAvailable"
+const (
+	// QuotaExceededDiskCapacity: The used capacity of disk type has exceeded the quota in the zone
+	QuotaExceededDiskCapacity = "QuotaExceed.DiskCapacity"
+	// QuotaExceededElasticQuota: The number of vCPUs assigned to the ECS instances has exceeded the quota in the zone. Please sign-on to Alibaba Cloud Console, and submit a quota increase application.
+	QuotaExceededElasticQuota = "QuotaExceed.ElasticQuota"
+	// OperationDeniedZoneSystemCategoryNotMatch: The specified Zone or cluster does not offer the specified disk category or the specified zone and cluster do not match.
+	OperationDeniedZoneSystemCategoryNotMatch = "OperationDenied.ZoneSystemCategoryNotMatch"
+	// OperationDeniedCloudSSDNotSupported: The specified available zone does not offer the cloud_ssd disk, use cloud_essd instead.
+	OperationDeniedCloudSSDNotSupported = "OperationDenied.CloudSSDNotSupported"
+	// OperationDeniedZoneNotAllowed: The creation of Instance to the specified Zone is not allowed.
+	OperationDeniedZoneNotAllowed = "OperationDenied.ZoneNotAllowed"
+	// OperationDeniedNoStock: The requested resource is sold out in the specified zone; try other types of resources or other regions and zones.
+	OperationDeniedNoStock = "OperationDenied.NoStock"
+	// ZoneNotOnSale: The resource in the specified zone is no longer available for sale. Please try other regions and zones.
+	ZoneNotOnSale = "Zone.NotOnSale"
+	// ZoneNotOpen: The specified zone is not granted to you to buy resources yet.
+	ZoneNotOpen = "Zone.NotOpen"
+	// InvalidVpcZone.NotSupported: The specified operation is not allowed in the zone to which your VPC belongs, please try in other zones.
+	InvalidVpcZoneNotSupported = "InvalidVpcZone.NotSupported"
+	// InvalidZoneIDNotSupportShareEncryptedImage: Creating instances by shared encrypted images is not supported in this zone.
+	InvalidZoneIDNotSupportShareEncryptedImage = "InvalidZoneId.NotSupportShareEncryptedImage"
+	// InvalidInstanceType.ZoneNotSupported: The specified zone does not support this instancetype.
+	InvalidInstanceTypeZoneNotSupported = "InvalidInstanceType.ZoneNotSupported"
+	// ResourceNotAvailable: Resource you requested is not available in this region or zone.
+	ResourceNotAvailable = "ResourceNotAvailable"
 )

--- a/pkg/alicloud/errors/utils.go
+++ b/pkg/alicloud/errors/utils.go
@@ -1,0 +1,20 @@
+package errors
+
+import (
+	alierr "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
+)
+
+// CreateMachineErrorToMCMErrorCode takes the error returned from the EC2API during the CreateMachine call and returns the corresponding MCM error code.
+func CreateMachineErrorToMCMErrorCode(err error) codes.Code {
+	aliErr, ok := err.(*alierr.ServerError)
+	if ok {
+		switch aliErr.ErrorCode() {
+		case QuotaExceededDiskCapacity, QuotaExceededElasticQuota, OperationDeniedCloudSSDNotSupported, OperationDeniedNoStock, OperationDeniedZoneNotAllowed, OperationDeniedZoneSystemCategoryNotMatch, ZoneNotOnSale, ZoneNotOpen, InvalidVpcZoneNotSupported, InvalidInstanceTypeZoneNotSupported, InvalidZoneIdNotSupportShareEncryptedImage, ResourceNotAvailable:
+			return codes.ResourceExhausted
+		default:
+			return codes.Internal
+		}
+	}
+	return codes.Internal
+}

--- a/pkg/alicloud/errors/utils.go
+++ b/pkg/alicloud/errors/utils.go
@@ -21,8 +21,8 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 )
 
-// CreateMachineErrorToMCMErrorCode takes the error returned from the EC2API during the CreateMachine call and returns the corresponding MCM error code.
-func CreateMachineErrorToMCMErrorCode(err error) codes.Code {
+// GetMCMErrorCodeForCreateMachine takes the error returned from the EC2API during the CreateMachine call and returns the corresponding MCM error code.
+func GetMCMErrorCodeForCreateMachine(err error) codes.Code {
 	aliErr, ok := err.(*alierr.ServerError)
 	if ok {
 		switch aliErr.ErrorCode() {

--- a/pkg/alicloud/errors/utils.go
+++ b/pkg/alicloud/errors/utils.go
@@ -3,13 +3,17 @@ Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package errors contains the error codes returned by Alicloud APIs
 package errors
 
 import (
@@ -22,7 +26,7 @@ func CreateMachineErrorToMCMErrorCode(err error) codes.Code {
 	aliErr, ok := err.(*alierr.ServerError)
 	if ok {
 		switch aliErr.ErrorCode() {
-		case QuotaExceededDiskCapacity, QuotaExceededElasticQuota, OperationDeniedCloudSSDNotSupported, OperationDeniedNoStock, OperationDeniedZoneNotAllowed, OperationDeniedZoneSystemCategoryNotMatch, ZoneNotOnSale, ZoneNotOpen, InvalidVpcZoneNotSupported, InvalidInstanceTypeZoneNotSupported, InvalidZoneIdNotSupportShareEncryptedImage, ResourceNotAvailable:
+		case QuotaExceededDiskCapacity, QuotaExceededElasticQuota, OperationDeniedCloudSSDNotSupported, OperationDeniedNoStock, OperationDeniedZoneNotAllowed, OperationDeniedZoneSystemCategoryNotMatch, ZoneNotOnSale, ZoneNotOpen, InvalidVpcZoneNotSupported, InvalidInstanceTypeZoneNotSupported, InvalidZoneIDNotSupportShareEncryptedImage, ResourceNotAvailable:
 			return codes.ResourceExhausted
 		default:
 			return codes.Internal

--- a/pkg/alicloud/errors/utils.go
+++ b/pkg/alicloud/errors/utils.go
@@ -1,3 +1,15 @@
+/*
+Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package errors
 
 import (

--- a/pkg/alicloud/errors/utils_test.go
+++ b/pkg/alicloud/errors/utils_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package errors
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	alierr "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
+	
+)
+
+type input struct {
+	inputAliErrorCode string
+	expectedCode      codes.Code
+}
+
+type responseContent struct {
+	Code string
+}
+
+func TestCreateMachineErrorToMCMErrorCode(t *testing.T) {
+	table := []input{
+		{inputAliErrorCode: OperationDeniedNoStock, expectedCode: codes.ResourceExhausted},
+		// InvalidImageId can't be resolved by trying another zone, so not treated as ResourceExhausted
+		{inputAliErrorCode: "InvalidImageId.NotFound", expectedCode: codes.Internal},
+	}
+	g := NewWithT(t)
+	for _, entry := range table {
+		jsonResponse, err := json.Marshal(responseContent{entry.inputAliErrorCode})
+		g.Expect(err).To(BeNil())
+		inputError := alierr.NewServerError(403, string(jsonResponse), "some error happened on the server side")
+		g.Expect(CreateMachineErrorToMCMErrorCode(inputError)).To(Equal(entry.expectedCode))
+	}
+}

--- a/pkg/alicloud/errors/utils_test.go
+++ b/pkg/alicloud/errors/utils_test.go
@@ -43,6 +43,6 @@ func TestCreateMachineErrorToMCMErrorCode(t *testing.T) {
 		jsonResponse, err := json.Marshal(responseContent{entry.inputAliErrorCode})
 		g.Expect(err).To(BeNil())
 		inputError := alierr.NewServerError(403, string(jsonResponse), "some error happened on the server side")
-		g.Expect(CreateMachineErrorToMCMErrorCode(inputError)).To(Equal(entry.expectedCode))
+		g.Expect(GetMCMErrorCodeForCreateMachine(inputError)).To(Equal(entry.expectedCode))
 	}
 }

--- a/pkg/alicloud/errors/utils_test.go
+++ b/pkg/alicloud/errors/utils_test.go
@@ -3,7 +3,9 @@ Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,10 +18,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	alierr "github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
-	
+	. "github.com/onsi/gomega"
 )
 
 type input struct {

--- a/pkg/alicloud/machine_controller.go
+++ b/pkg/alicloud/machine_controller.go
@@ -92,7 +92,7 @@ func (plugin *MachinePlugin) CreateMachine(ctx context.Context, req *driver.Crea
 
 	response, err := client.RunInstances(request)
 	if err != nil {
-		return nil, status.Error(maperror.CreateMachineErrorToMCMErrorCode(err), err.Error())
+		return nil, status.Error(maperror.GetMCMErrorCodeForCreateMachine(err), err.Error())
 	}
 
 	instanceID := response.InstanceIdSets.InstanceIdSet[0]

--- a/pkg/alicloud/machine_controller.go
+++ b/pkg/alicloud/machine_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
+	maperror "github.com/gardener/machine-controller-manager-provider-alicloud/pkg/alicloud/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -91,7 +92,7 @@ func (plugin *MachinePlugin) CreateMachine(ctx context.Context, req *driver.Crea
 
 	response, err := client.RunInstances(request)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(maperror.CreateMachineErrorToMCMErrorCode(err), err.Error())
 	}
 
 	instanceID := response.InstanceIdSets.InstanceIdSet[0]

--- a/pkg/alicloud/machine_controller.go
+++ b/pkg/alicloud/machine_controller.go
@@ -21,11 +21,11 @@ import (
 	"context"
 	"fmt"
 
+	maperror "github.com/gardener/machine-controller-manager-provider-alicloud/pkg/alicloud/errors"
 	"github.com/gardener/machine-controller-manager-provider-alicloud/pkg/spi"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
-	maperror "github.com/gardener/machine-controller-manager-provider-alicloud/pkg/alicloud/errors"
 	"k8s.io/klog/v2"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Utilizes ResourceExhausted error status code. Only the errors which happen in a particular zone and are relating to insufficiency of resources are mapped to ResourceExhausted.
The intention is to enable CA to identify such errors , so that it could try another zone quicker
https://github.com/gardener/autoscaler/issues/154

**Which issue(s) this PR fixes**:
Fixes # 
Partially fixes https://github.com/gardener/machine-controller-manager/issues/590

**Special notes for your reviewer**:
Testing done for `ResourceExhausted` error code.
```
I0913 17:21:13.756129   45533 machine_controller.go:95] Machine creation request has been processed for "shoot--i544024--ali-test-worker-1-eu-central-1b-7768f-6htmb"
E0913 17:21:13.756174   45533 machine.go:359] Error while creating machine shoot--i544024--ali-test-worker-1-eu-central-1b-7768f-6htmb: machine codes error: code = [ResourceExhausted] message = [SDK.ServerError
ErrorCode: OperationDenied.NoStock
Recommend: https://error-center.aliyun.com/status/search?Keyword=Zone.NotOnSale&source=PopGw
RequestId: AB66A046-C124-3B25-AC34-E8459C965884
Message: The resource in the specified zone is no longer available for sale. Please try other regions and zones.], "shoot--bksrv-dev--ac-bksrv-1-system-eu-central-1a-6c67f-vq6m6"]
```

Tickets opened related to these :
kubernetes-ac-canary/issues-ac-canary/issues/31
canary # 1742

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
MCM status code `ResourceExhausted` is now utilized in mcm-provider-alicloud.
```
