### PR TITLE
Moved Declaration of dynamic content from Makefile to .env file for Alicloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /dev
 /logs
 .ci/controllers-test/logs
-
+.env
 .vscode
 .idea
 *.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LEADER_ELECT 	    := "true"
 # with MCM deployment name in the cluster
 MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 
-include .env
+-include .env
 
 #########################################
 # Rules for running helper scripts

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include .env
+
 BINARY_PATH         := bin/
 COVERPROFILE        := test/output/coverprofile.out
 IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-alicloud
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := alicloud
 PROJECT_NAME        := gardener
-
 LEADER_ELECT 	    := "true"
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
 MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
-
--include .env
 
 #########################################
 # Rules for running helper scripts

--- a/Makefile
+++ b/Makefile
@@ -18,21 +18,13 @@ IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-ma
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := alicloud
 PROJECT_NAME        := gardener
-CONTROL_NAMESPACE   :=
-CONTROL_KUBECONFIG  :=
-TARGET_KUBECONFIG   :=
 
-# Below ones are used in tests
-MACHINECLASS_V1 	:= dev/machineclassv1.yaml
-MACHINECLASS_V2 	:=
-MCM_IMAGE			:=
-MC_IMAGE			:=
-# MCM_IMAGE			:= eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.46.0
-# MC_IMAGE			:= $(IMAGE_REPOSITORY):v0.6.0
 LEADER_ELECT 	    := "true"
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
 MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
+
+include .env
 
 #########################################
 # Rules for running helper scripts


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Makefile content to import dynamic content from the .env file.

**Which issue(s) this PR fixes**:
Fixes -> https://github.com/gardener/machine-controller-manager/issues/846

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```