### PR TITLE
Fetch kubeconfigs before check_cluster_state

### DIFF
--- a/.ci/pipeline_integration_test
+++ b/.ci/pipeline_integration_test
@@ -204,8 +204,6 @@ function setup_environment() {
     fi
 
     #fetching kubeconfigs and machineClass from secret_server
-    fetch_service_account_kubeconfig
-    fetch_oot_cluster_kubeconfig
     create_test_mc_secret
     echo "test-mc-secret created successfully"
     fetch_machine_class
@@ -276,6 +274,8 @@ function print_controller_logs {
 ############################################## <Main> ########################################################
 
 printf "\n\t\t\t----- Start of Test Script -----------\n"
+fetch_service_account_kubeconfig
+fetch_oot_cluster_kubeconfig
 #if cluster state is not clean then don't run the tests
 check_cluster_state
 setup_environment


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```