### PR TITLE
Replace goling with golangci-lint

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -6,11 +6,34 @@
 
 set -e
 
-source "$(dirname ${0})/setupenv.src"
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
+else
+  READLINK_BIN="readlink"
+fi
 
-go install golang.org/x/lint/golint
+if [[ -z "${SOURCE_PATH}" ]]; then
+  export SOURCE_PATH="$(${READLINK_BIN} -f $(dirname ${0})/..)"
+else
+  export SOURCE_PATH="$(${READLINK_BIN} -f "${SOURCE_PATH}")"
+fi
+
+export GOBIN="${SOURCE_PATH}/tmp/bin"
+export PATH="${GOBIN}:${PATH}"
 
 ###############################################################################
+# Install golangci-lint (linting tool).
+if [[ -z "${GOLANGCI_LINT_VERSION}" ]]; then
+  export GOLANGCI_LINT_VERSION=v1.57.1
+fi
+echo "Fetching golangci-lint tool"
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@"${GOLANGCI_LINT_VERSION}"
+echo "Successfully fetched golangci-lint"
+golangci-lint version
+
+###############################################################################
+cd ${SOURCE_PATH}
+
 PACKAGES="$(go list -e ./... | grep -vE '/internal/flags')"
 PACKAGES_DIRS="$(echo ${PACKAGES} | sed "s|github.com/gardener/machine-controller-manager-provider-alicloud|.|g")"
 
@@ -23,8 +46,7 @@ echo "Running gofmt..."
 gofmt -l -w -s ${PACKAGES_DIRS}
 
 # Execute lint checks.
-echo "Running golint..."
-for package in ${PACKAGES_DIRS}; do
-    golint -set_exit_status $(find $package -maxdepth 1 -name "*.go" | grep -vE 'zz_generated|_test.go')
-done
+echo "Executing golangci-lint..."
+# golangci-lint can't be run from outside the directory
+(cd ${SOURCE_PATH} && golangci-lint run -c .golangci.yaml --timeout 10m)
 echo "Check script has passed successfully"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,49 @@
+run:
+  concurrency: 4
+  timeout: 10m
+
+linters:
+  disable:
+    - unused
+  enable:
+    - revive
+    - loggercheck
+
+issues:
+  exclude-use-default: false
+  exclude:
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+    # revive:
+    - var-naming # ((var|const|struct field|func) .* should be .*
+    - dot-imports # should not use dot imports
+    - package-comments # package comment should be of the form
+    - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
+    - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+    - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
+    # typecheck:
+    - "undeclared name: `.*`"
+    - "\".*\" imported but not used"
+    # allow non-capitalized messages if they start with technical terms
+    - "structured logging message should be capitalized: \"garden(er-apiserver|er-controller-manager|er-admission-controller|er-operator|er-resource-manager|let)"
+  exclude-rules:
+    - linters:
+        - staticcheck
+      text: "SA1019:" # Excludes messages where deprecated variables are used
+
+  exclude-files:
+    - "zz_generated\\..*\\.go$"
+
+linters-settings:
+  revive:
+    rules:
+      - name: duplicated-imports
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: context-as-argument
+      - name: early-return
+      - name: exported
+  loggercheck:
+    no-printf-like: true
+    logr: true
+    zap: true

--- a/pkg/alicloud/apis/alicloud_provider_spec.go
+++ b/pkg/alicloud/apis/alicloud_provider_spec.go
@@ -33,12 +33,12 @@ type ProviderSpec struct {
 
 // AlicloudDataDisk describes DataDisk for Alicloud.
 type AlicloudDataDisk struct {
-	Name               string `json:"name,omitEmpty"`
-	Category           string `json:"category,omitEmpty"`
-	Description        string `json:"description,omitEmpty"`
-	Encrypted          bool   `json:"encrypted,omitEmpty"`
-	DeleteWithInstance *bool  `json:"deleteWithInstance,omitEmpty"`
-	Size               int    `json:"size,omitEmpty"`
+	Name               string `json:"name,omitempty"`
+	Category           string `json:"category,omitempty"`
+	Description        string `json:"description,omitempty"`
+	Encrypted          bool   `json:"encrypted,omitempty"`
+	DeleteWithInstance *bool  `json:"deleteWithInstance,omitempty"`
+	Size               int    `json:"size,omitempty"`
 }
 
 // AlicloudSystemDisk describes SystemDisk for Alicloud.

--- a/pkg/alicloud/apis/validation/validation.go
+++ b/pkg/alicloud/apis/validation/validation.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ValidateProviderSpecNSecret validates provider spec and secret to check if all fields are present and valid
-func ValidateProviderSpecNSecret(spec *api.ProviderSpec, secrets *corev1.Secret) []error {
+func ValidateProviderSpecNSecret(_ *api.ProviderSpec, _ *corev1.Secret) []error {
 	// Code for validation of providerSpec goes here
 	return nil
 }

--- a/pkg/alicloud/machine_controller.go
+++ b/pkg/alicloud/machine_controller.go
@@ -52,7 +52,7 @@ import (
 // It is optionally expected by the safety controller to use an identification mechanisms to map the VM Created by a providerSpec.
 // These could be done using tag(s)/resource-groups etc.
 // This logic is used by safety controller to delete orphan VMs which are not backed by any machine CRD
-func (plugin *MachinePlugin) CreateMachine(ctx context.Context, req *driver.CreateMachineRequest) (*driver.CreateMachineResponse, error) {
+func (plugin *MachinePlugin) CreateMachine(_ context.Context, req *driver.CreateMachineRequest) (*driver.CreateMachineResponse, error) {
 	// Log messages to track request
 	klog.V(2).Infof("Machine creation request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine creation request has been processed for %q", req.Machine.Name)
@@ -110,7 +110,7 @@ func (plugin *MachinePlugin) InitializeMachine(_ context.Context, _ *driver.Init
 // LastKnownState        bytes(blob)              (Optional) Last known state of VM during the current operation.
 //
 //	Could be helpful to continue operations in future requests.
-func (plugin *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMachineRequest) (*driver.DeleteMachineResponse, error) {
+func (plugin *MachinePlugin) DeleteMachine(_ context.Context, req *driver.DeleteMachineRequest) (*driver.DeleteMachineResponse, error) {
 	// Log messages to track delete request
 	klog.V(2).Infof("Machine deletion request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
@@ -187,7 +187,7 @@ func (plugin *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.Dele
 //	This could be different from req.MachineName as well
 //
 // The request should return a NOT_FOUND (5) status error code if the machine is not existing
-func (plugin *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMachineStatusRequest) (*driver.GetMachineStatusResponse, error) {
+func (plugin *MachinePlugin) GetMachineStatus(_ context.Context, req *driver.GetMachineStatusRequest) (*driver.GetMachineStatusResponse, error) {
 	// Log messages to track start and end of request
 	klog.V(2).Infof("Get request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine get request has been processed successfully for %q", req.Machine.Name)
@@ -254,7 +254,7 @@ func (plugin *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.G
 // MachineList           map<string,string>  A map containing the keys as the MachineID and value as the MachineName
 //
 //	for all machine's who where possibilly created by this ProviderSpec
-func (plugin *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachinesRequest) (*driver.ListMachinesResponse, error) {
+func (plugin *MachinePlugin) ListMachines(_ context.Context, req *driver.ListMachinesRequest) (*driver.ListMachinesResponse, error) {
 	// Log messages to track start and end of request
 	klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
 	defer klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
@@ -303,7 +303,7 @@ func (plugin *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListM
 //
 // RESPONSE PARAMETERS (driver.GetVolumeIDsResponse)
 // VolumeIDs             []string                             VolumeIDs is a repeated list of VolumeIDs.
-func (plugin *MachinePlugin) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
+func (plugin *MachinePlugin) GetVolumeIDs(_ context.Context, req *driver.GetVolumeIDsRequest) (*driver.GetVolumeIDsResponse, error) {
 	// Log messages to track start and end of request
 	klog.V(2).Infof("GetVolumeIDs request has been recieved for %q", req.PVSpecs)
 	defer klog.V(2).Infof("GetVolumeIDs request has been processed successfully for %q", req.PVSpecs)

--- a/test/integration/controller/controller_test.go
+++ b/test/integration/controller/controller_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 // the timeout is changed to accommodate for time taken by node-critical components to get ready. PR - https://github.com/gardener/machine-controller-manager/pull/778
-var commons = common.NewIntegrationTestFramework(&provider.ResourcesTrackerImpl{}, 600)
+var commons = common.NewIntegrationTestFramework(&provider.ResourcesTrackerImpl{}, 900)
 
 var _ = BeforeSuite(commons.SetupBeforeSuite)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the deprecated `golint` with `golangci-lint`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
golangci-lint will now be used as the linter instead of the older golint
```