### PR TITLE
Adapt pipeline_definitions to include SAST linting logs in OCM descriptor

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,5 +1,12 @@
 machine-controller-manager-provider-alicloud:
   base_definition:
+    repo:
+      source_labels:
+        - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+          value:
+            policy: skip
+            comment: |
+              we use gosec for sast scanning. See attached log.
     traits:
       version: ~
       component_descriptor:
@@ -71,6 +78,16 @@ machine-controller-manager-provider-alicloud:
           ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
+          assets:
+            - type: build-step-log
+              step_name: check
+              purposes:
+                - lint
+                - sast
+                - gosec
+              comment: |
+                we use gosec (linter) for SAST scans
+                see: https://github.com/securego/gosec
         publish:
           dockerimages:
             <<: *default_images


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR changes pipeline_definitions to include SAST linting logs in OCM descriptor.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```