### PR TITLE
Fix flaky unit test

### DIFF
--- a/pkg/alicloud/machine_controller_test.go
+++ b/pkg/alicloud/machine_controller_test.go
@@ -203,6 +203,7 @@ var _ = Describe("Machine Controller", func() {
 			response, err := mockMachinePlugin.DeleteMachine(ctx, deleteMachineRequest)
 			Expect(err).To(BeNil())
 			Expect(response).To(Equal(deleteMachineResponse))
+			deleteMachineRequest.Machine.Spec.ProviderID = providerID //Need to add this value back as other tests are dependent on this
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We noticed that sometimes unit tests were failing randomly. 
It was found that a newly added test case was dependent on removing the value at `machine.spec.providerID`. This value was not added back after this particular test case and when tests are run in a random order, test cases that depend on this value would fail if run after this test case

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @takoverflow 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```