### PR TITLE
Use debian 12 distroless image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      machine-controller               #############
-FROM gcr.io/distroless/static-debian11:nonroot AS machine-controller
+FROM gcr.io/distroless/static-debian12:nonroot AS machine-controller
 WORKDIR /
 
 COPY --from=builder /go/src/github.com/gardener/machine-controller-manager-provider-alicloud/bin/rel/machine-controller /machine-controller


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades base image used from `gcr.io/distroless/static-debian11:nonroot` to `gcr.io/distroless/static-debian12:nonroot`

**Which issue(s) this PR fixes**:
Fixes partially gardener/machine-controller-manager#982

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
machine-controller-manager-provider-alicloud base image is updated to `gcr.io/distroless/static-debian12:nonroot`
```