### PR TITLE
Add arm64 arch to oci-platforms

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
       version: ${{ needs.prepare.outputs.version }}
       oci-registry: ${{ needs.prepare.outputs.oci-registry }}
       oci-repository: ${{ matrix.args.oci-repository }}
-      oci-platforms: linux/amd64
+      oci-platforms: linux/amd64,linux/arm64
       ocm-labels: ${{ toJSON(matrix.args.ocm-labels) }}
 
   check:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the github build workflow to add a new arch type to oci-platforms. This ensures that arm64 images will now be built by this workflow

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Update build workflow to now also build arm64 images
```