### PR TITLE
fix: typo (occured -> occurred) in integration test logs

### DIFF
--- a/test/integration/provider/alicloud.go
+++ b/test/integration/provider/alicloud.go
@@ -40,11 +40,11 @@ func newSession(machineClass *v1alpha1.MachineClass, secret *v1.Secret) spi.ECSC
 	err := json.Unmarshal([]byte(machineClass.ProviderSpec.Raw), &providerSpec)
 	if err != nil {
 		providerSpec = nil
-		log.Printf("Error occured while performing unmarshal %s", err.Error())
+		log.Printf("Error occurred while performing unmarshal %s", err.Error())
 	}
 	sess, err := sPI.NewECSClient(secret, providerSpec.Region)
 	if err != nil {
-		log.Printf("Error occured while creating new session %s", err)
+		log.Printf("Error occurred while creating new session %s", err)
 	}
 	return sess
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes 'occured' -> 'occurred' typo in integration test log messages (test/integration/provider/alicloud.go).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
String/comment-only change, no functional impact.

**Release note**:
```other operator
NONE
```
