### PR TITLE
Fix multi-arch container image build to compile `TARGETARCH` binary instead of always `amd64`

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -6,16 +6,16 @@
 
 set -e
 
-source "$(dirname ${0})/setupenv.src"
+source "$(readlink -f $(dirname ${0}))/setupenv.src"
 
 VERSION=$(cat VERSION)
 
 ###############################################################################
 
 # If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux OS, amd64 architectures and without CGO enablement.
+# to build for the local/default OS and ARCH and without CGO enablement.
 if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+  CGO_ENABLED=0 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) go build \
     -a \
     -o ${BINARY_PATH}/rel/machine-controller \
     -ldflags "-X main.version=$VERSION-$(git rev-parse HEAD)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 #############      builder                          #############
-FROM golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-alicloud
 COPY . .
 
-RUN .ci/build
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH .ci/build
 
 #############      machine-controller               #############
 FROM gcr.io/distroless/static-debian12:nonroot AS machine-controller

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := alicloud
 PROJECT_NAME        := gardener
 LEADER_ELECT 	    := "true"
+TARGET_PLATFORMS    ?= linux/$(shell go env GOARCH)
 IS_CONTROL_CLUSTER_SEED 	:= true
 # If Integration Test Suite is to be run locally against clusters then export the below variable
 # with MCM deployment name in the cluster
@@ -86,10 +87,9 @@ build-local:
 build:
 	@.ci/build
 
-PLATFORM ?= linux/amd64
 .PHONY: docker-image
 docker-image:
-	@docker buildx build --platform $(PLATFORM) -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) .
+	@docker buildx build --platform $(TARGET_PLATFORMS) -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) .
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix multi-arch container image build to compile `TARGETARCH` binary instead of always `amd64`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix multi-arch container image build to compile the binary for the configured `TARGETARCH` instead of always for `amd64`, i.e. the `arm64` image now contains `arm64` binary instead of `amd64`. 
```


cc @adenitiu